### PR TITLE
Declare parameters for the arm and gripper types.

### DIFF
--- a/src/piper_control_ros2/piper_control_ros2/piper_control_node.py
+++ b/src/piper_control_ros2/piper_control_ros2/piper_control_node.py
@@ -9,12 +9,7 @@ import os
 import signal
 
 import rclpy
-from piper_control import (
-    piper_connect,
-    piper_control,
-    piper_init,
-    piper_interface,
-)
+from piper_control import piper_connect, piper_control, piper_init, piper_interface
 from rclpy import logging
 from rclpy.node import Node
 from sensor_msgs import msg as sensor_msgs
@@ -139,6 +134,20 @@ class PiperControlNode(Node):
         .string_value
     )
 
+    self.declare_parameter("piper_arm_type", "PIPER")
+    self._piper_arm_type = (
+        self.get_parameter("piper_arm_type")
+        .get_parameter_value()
+        .string_value
+    )
+
+    self.declare_parameter("piper_gripper_type", "V2")  # 10 cm gripper.
+    self._piper_gripper_type = (
+        self.get_parameter("piper_gripper_type")
+        .get_parameter_value()
+        .string_value
+    )
+
     # Create a CAN connection to robot.
     ports = piper_connect.find_ports()
     print(f"Available ports: {ports}")
@@ -157,7 +166,11 @@ class PiperControlNode(Node):
           f"{readme}",
       )
 
-    self._robot = piper_interface.PiperInterface(can_port=self.can_port)
+    self._robot = piper_interface.PiperInterface(
+      can_port=self.can_port,
+      piper_arm_type=_get_piper_arm_type(self._piper_arm_type),
+      piper_gripper_type=_get_piper_gripper_type(self._piper_gripper_type),
+    )
 
     # Get the appropriate rest position based on arm orientation
     arm_orientation = piper_control.ArmOrientations.from_string(
@@ -332,6 +345,8 @@ class PiperControlNode(Node):
     )
     self.get_logger().info(f"  arm_orientation: {self.arm_orientation}")
     self.get_logger().info(f"  firmware_version: {firmware_version}")
+    self.get_logger().info(f"  arm type: {self._piper_arm_type}")
+    self.get_logger().info(f"  gripper type: {self._piper_gripper_type}")
     return gravity_compensation.GravityCompensationModel(
         samples_path=self.gravity_samples_path,
         model_path=self.gravity_model_mujoco_path,
@@ -704,6 +719,30 @@ class PiperControlNode(Node):
     metadata["arm_orientation"] = self.arm_orientation
     msg = std_msgs.String(data=json.dumps(metadata))
     self.node_metadata_pub.publish(msg)
+
+
+def _get_piper_arm_type(
+    piper_arm_type_str: str,
+) -> piper_interface.PiperArmType:
+  try:
+    return piper_interface.PiperArmType[piper_arm_type_str]
+  except KeyError as e:
+    raise ValueError(
+        f"Invalid piper_arm_type: {piper_arm_type_str}. Valid options are: "
+        f"{[t.name for t in piper_interface.PiperArmType]}",
+    ) from e
+
+def _get_piper_gripper_type(
+    piper_gripper_type_str: str,
+) -> piper_interface.PiperGripperType:
+  try:
+    return piper_interface.PiperGripperType[piper_gripper_type_str]
+  except KeyError as e:
+    raise ValueError(
+        f"Invalid piper_gripper_type: {piper_gripper_type_str}. "
+        "Valid options are: "
+        f"{[t.name for t in piper_interface.PiperGripperType]}",
+    ) from e
 
 
 def term_handler(signum, frame, node: PiperControlNode) -> None:

--- a/src/piper_control_ros2/piper_control_ros2/piper_control_node.py
+++ b/src/piper_control_ros2/piper_control_ros2/piper_control_node.py
@@ -136,9 +136,7 @@ class PiperControlNode(Node):
 
     self.declare_parameter("piper_arm_type", "PIPER")
     self._piper_arm_type = (
-        self.get_parameter("piper_arm_type")
-        .get_parameter_value()
-        .string_value
+        self.get_parameter("piper_arm_type").get_parameter_value().string_value
     )
 
     self.declare_parameter("piper_gripper_type", "V2")  # 10 cm gripper.
@@ -167,9 +165,9 @@ class PiperControlNode(Node):
       )
 
     self._robot = piper_interface.PiperInterface(
-      can_port=self.can_port,
-      piper_arm_type=_get_piper_arm_type(self._piper_arm_type),
-      piper_gripper_type=_get_piper_gripper_type(self._piper_gripper_type),
+        can_port=self.can_port,
+        piper_arm_type=_get_piper_arm_type(self._piper_arm_type),
+        piper_gripper_type=_get_piper_gripper_type(self._piper_gripper_type),
     )
 
     # Get the appropriate rest position based on arm orientation
@@ -731,6 +729,7 @@ def _get_piper_arm_type(
         f"Invalid piper_arm_type: {piper_arm_type_str}. Valid options are: "
         f"{[t.name for t in piper_interface.PiperArmType]}",
     ) from e
+
 
 def _get_piper_gripper_type(
     piper_gripper_type_str: str,


### PR DESCRIPTION
This allows us to use the correct joint and gripper limits for the arm inside the control node.